### PR TITLE
Expose a immutable client conf object

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,26 +7,28 @@ var crypto = require('crypto');
  * @TODO Testing
  */
 function Client (conf) {
+  this.conf = Object.freeze(conf);
+}
 
+Client.prototype = {
   /**
    * Calculates the hash for a user so an external userbase can be linked to hull.io services
    *
    * @param {mixed} user The derscription of the user. Developers are free to use the keys they see fit, as long as it is JSON.stringify'able.
    * @returns {String} The hash to identity the user
    */
-  this.getUserHash = function (user) {
+  getUserHash: function (user) {
     var timestamp = Date.now();
     var message = (new Buffer(JSON.stringify(user))).toString('base64');
-    var signature = crypto.createHmac('sha1', conf.appSecret).update([message, timestamp].join(' ')).digest('hex');
+    var signature = crypto.createHmac('sha1', this.conf.appSecret).update([message, timestamp].join(' ')).digest('hex');
     var parts = [
       message,
       signature,
       timestamp
     ];
     return parts.join(' ');
-  };
-
-}
+  }
+};
 
 exports = module.exports = function (conf) {
   //Generates a new client with the configuration passed


### PR DESCRIPTION
Instead of not exposing it, we expose an `Object.freezed` version
of itself.
