### PR TITLE
Optional options

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -44,10 +44,12 @@ function genericRequest(/*method, conf, path, params, callback*/) {
     .set('Hull-Access-Token', conf.appSecret)
     .set('User-Agent', 'Hull Node Client v' + conf.version);
 
-  if (req.method === 'GET') {
-    req.query(params);
-  } else {
-    req.send(params);
+  if (params) {
+    if (req.method === 'GET') {
+      req.query(params);
+    } else {
+      req.send(params);
+    }
   }
 
   return req.end(function (err, res) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,11 +63,18 @@ module.exports = {
   },
   buildAccessToken: function (config, userId) {
     var iat = Math.floor(new Date().getTime() / 1000);
-    return jwt.encode({
+    var claims = {
       iss: config.appId,
-      sub: userId,
       iat: iat,
       exp: iat + 600
-    }, config.appSecret);
+    };
+    if (userId instanceof Object) {
+      claims['io.hull.user'] = userId;
+    }
+    else {
+      claims.sub = userId;
+    }
+
+    return jwt.encode(claims, config.appSecret);
   }
 };

--- a/spec/indexSpec.js
+++ b/spec/indexSpec.js
@@ -14,7 +14,7 @@ describe('module exports', function () {
     hull.should.be.a('function');
   });
   it('should have some properties', function () {
-    hull.should.have.keys(['as', 'client', 'utils', 'middleware', 'conf', ]);
+    hull.should.have.keys(['as', 'client', 'utils', 'middleware', 'conf', 'webhook']);
   });
   it('should return an instance of the HTTP client', function () {
     hull({appId:true, orgUrl:true, appSecret:true}).should.be.instanceOf(Client);

--- a/spec/utilsSpec.js
+++ b/spec/utilsSpec.js
@@ -1,10 +1,29 @@
 "use strict";
 var chai = require('chai'),
-    sinon = require('sinon');
+    sinon = require('sinon'),
+    jwt = require('jwt-simple'),
+    utils = require('../lib/utils.js');
 chai.use(require('sinon-chai'));
 chai.should();
 
-xdescribe('utils', function () {
-  it('should generate a signature from a user id');
-  it('should validate a signature');
+describe('utils', function () {
+  describe('buildAccessToken', function () {
+    var user = {
+      external_id: 'foo'
+    };
+    var config = {
+      appId: 'appid',
+      appSecret: 'secret'
+    };
+    it ('should sign a jwt for user hash', function () {
+      var token = jwt.decode(utils.buildAccessToken(config, user), config.appSecret);
+      token.should.have.property('io.hull.user');
+      token.should.not.have.property('sub');
+    });
+    it ('should sign a jwt for a user id', function () {
+      var token = jwt.decode(utils.buildAccessToken(config, 'user'), config.appSecret);
+      token.should.not.have.property('io.hull.user');
+      token.should.have.property('sub');
+    });
+  });
 });


### PR DESCRIPTION
Enables: hull.as(user).get('/me', function (err, res) {...});
instead of hull.as(user).get('/me', {}, function...
