### PR TITLE
fix current user middleware and npm issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hull",
   "version": "0.5.0",
   "description": "A Node.js client for hull.io APIs",
-  "main": "dist/index.js",
+  "main": "lib",
   "repository": {
     "type": "git",
     "url": "https://github.com/hull/hull-node.git"

--- a/src/current-user.js
+++ b/src/current-user.js
@@ -29,4 +29,5 @@ export default function(config = {}, req, res, next) {
       req.hull.userId = userId;
     }
   }
+  next()
 }

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ const Client = function Client(config = {}) {
   };
 
   this.currentUserMiddleware = function(req, res, next) {
-    return currentUserMiddleware(clientConfig, req, res, next);
+    return currentUserMiddleware(clientConfig.get(), req, res, next);
   };
 
   this.webhookMiddleware = function(req, res, next) {


### PR DESCRIPTION
So I spent close to an hour trying to get the current user middleware to work, and it seems like the code was not even tested locally to see if it is working or not :-1: 

This pr fixes two issues:
1. Module not being exported correctly, if you install through `npm` the `main` property in package.json is set to `dist/index.js` but the gulp build will output to a folder by the name `lib`, so that should be used instead.
2. The configuration was not being passed correctly to the middleware, as well as next was not being called to move through the middleware stack.

Best,
Agon