### PR TITLE
Introduces caching manager to Hull client middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
+    "bluebird": "^3.4.6",
     "chai": "^3.5.0",
     "del": "^2.2.0",
     "eslint": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "JSONStream": "^1.1.2",
     "body-parser": "^1.15.2",
+    "cache-manager": "^2.1.2",
     "connect": "^3.4.1",
     "csv-stream": "^0.1.3",
     "del": "^2.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import NotifHandler from "./notif-handler";
 import BatchHandler from "./batch-handler";
 import OAuthHandler from "./oauth-handler";
+import ShipCache from "./ship-cache";
 
 import hullClient from "./middleware/client";
 import Client from "./client";
@@ -14,5 +15,6 @@ Client.Routes = { Readme, Manifest };
 Client.NotifHandler = NotifHandler.bind(undefined, Client);
 Client.BatchHandler = BatchHandler.bind(undefined, Client);
 Client.OAuthHandler = OAuthHandler.bind(undefined, Client);
+Client.ShipCache = ShipCache;
 
 module.exports = Client;

--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -1,4 +1,5 @@
 import jwt from "jwt-simple";
+import cacheManager from "cache-manager";
 
 function parseQueryString(query) {
   return ["organization", "ship", "secret"].reduce((cfg, k) => {
@@ -25,7 +26,7 @@ function parseToken(token, secret) {
 }
 
 
-module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true }) {
+module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, cachingAdapter = null }) {
   const _cache = [];
 
   /* TODO: Expire Cache after x minutes. For now, doesnt expire... Returns a Promise<ship> */

--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -26,20 +26,25 @@ function parseToken(token, secret) {
   }
 }
 
+function shipCacheFactory(cacheShip) {
+  // setup default CacheManager
+  const cacheAdapter = CacheManager.caching({
+    store: 'memory',
+    isCacheableValue: (val) => val !== undefined && cacheShip,
+    max: 100,
+    ttl: 10/*seconds*/
+  });
 
-module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, cacheAdapter = null }) {
-  if (cacheAdapter === null) {
-    // setup default CacheManager
-    cacheAdapter = CacheManager.caching({
-      store: 'memory',
-      isCacheableValue: (val) => val !== undefined && cacheShip,
-      max: 100,
-      ttl: 10/*seconds*/
-    });
+  return new ShipCache(cacheAdapter);
+}
+
+
+module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, shipCache = null }) {
+  if (shipCache === null) {
+    shipCache = shipCacheFactory(cacheShip);
   }
 
   function getCurrentShip(id, client, bust) {
-    const shipCache = new ShipCache(cacheAdapter);
     return (() => {
       if (bust) {
         return shipCache.del(id);

--- a/src/notif-handler.js
+++ b/src/notif-handler.js
@@ -144,7 +144,7 @@ function processHandlers(handlers) {
 }
 
 
-module.exports = function NotifHandler(Client, { handlers = [], hostSecret, groupTraits, onSubscribe }) {
+module.exports = function NotifHandler(Client, { handlers = [], hostSecret, groupTraits, onSubscribe, shipCache = null }) {
   const _handlers = {};
   const app = connect();
 
@@ -170,7 +170,7 @@ module.exports = function NotifHandler(Client, { handlers = [], hostSecret, grou
     enforceValidation: false,
     groupTraits: groupTraits !== false
   }));
-  app.use(hullClient(Client, { hostSecret, fetchShip: true, cacheShip: true }));
+  app.use(hullClient(Client, { hostSecret, fetchShip: true, cacheShip: true, shipCache }));
   app.use(processHandlers(_handlers));
   app.use((req, res) => { res.end("ok"); });
 

--- a/src/oauth-handler.js
+++ b/src/oauth-handler.js
@@ -27,7 +27,8 @@ export default function oauth(Client, {
   hostSecret = "",
   Strategy,
   views = {},
-  options = {}
+  options = {},
+  shipCache = null
 }) {
   function getURL(req, url, qs = { token: req.hull.token }) {
     return `https://${req.hostname}${req.baseUrl}${url}?${querystring.stringify(qs)}`;
@@ -60,7 +61,7 @@ export default function oauth(Client, {
   passport.use(strategy);
 
 
-  const hullMiddleware = hullClient(Client, { hostSecret, fetchShip: true, cacheShip: false });
+  const hullMiddleware = hullClient(Client, { hostSecret, fetchShip: true, cacheShip: false, shipCache });
 
   router.get(HOME_URL, hullMiddleware, (req, res) => {
     const { client, ship = {}, } = req.hull;

--- a/src/ship-cache.js
+++ b/src/ship-cache.js
@@ -1,0 +1,58 @@
+/**
+ * This is a wrapper over https://github.com/BryanDonovan/node-cache-manager
+ * to manage ship cache storage.
+ * It is responsible for handling cache key for every ship,
+ * and support namespaces.
+ */
+export default class ShipCache {
+
+  /**
+   * @param {Object} cache instance of cache-manager
+   * @param {String} namespace name of the namespace
+   */
+  constructor(cache, namespace) {
+    this.cache = cache;
+    this.namespace = namespace || "global";
+  }
+
+  /**
+   * @param {String} id the ship id
+   * @return {String}
+   */
+  getShipKey(id) {
+    return `${this.namespace}_ship-${id}`;
+  }
+
+  /**
+   * Hull client calls which fetch ship settings could be wrapped with this
+   * method to cache the results
+   * @see https://github.com/BryanDonovan/node-cache-manager#overview
+   * @param {String} id
+   * @param {Function} cb callback which Promised result would be cached
+   * @return {Promise}
+   */
+  wrap(id, cb) {
+    const shipCacheKey = this.getShipKey(id);
+    return this.cache.wrap(shipCacheKey, cb);
+  }
+
+  /**
+   * Saves ship data to the cache
+   * @param  {Object} ship
+   * @return {Promise}
+   */
+  set(ship) {
+    const shipCacheKey = this.getShipKey(ship.id);
+    return this.cache.set(shipCacheKey, ship);
+  }
+
+  /**
+   * Clears the ship cache
+   * @param  {String} id
+   * @return Promise
+   */
+  del(id) {
+    const shipCacheKey = this.getShipKey(id);
+    return this.cache.del(shipCacheKey);
+  }
+}

--- a/src/ship-cache.js
+++ b/src/ship-cache.js
@@ -38,11 +38,12 @@ export default class ShipCache {
 
   /**
    * Saves ship data to the cache
+   * @param  {String} id ship id
    * @param  {Object} ship
    * @return {Promise}
    */
-  set(ship) {
-    const shipCacheKey = this.getShipKey(ship.id);
+  set(id, ship) {
+    const shipCacheKey = this.getShipKey(id);
     return this.cache.set(shipCacheKey, ship);
   }
 

--- a/tests/client-middleware-cache.js
+++ b/tests/client-middleware-cache.js
@@ -56,12 +56,11 @@ describe("Client Middleware", () => {
     instance(reqStub, {}, (err) => {
       expect(reqStub.hull.ship.private_settings.value).to.equal("test");
       const newShip = {
-        id: "ship_id",
         private_settings: {
           value: "test2"
         }
       };
-      shipCache.set(newShip)
+      shipCache.set("ship_id", newShip)
         .then((arg) => {
           instance(reqStub, {}, () => {
             expect(reqStub.hull.ship.private_settings.value).to.equal("test2");
@@ -99,12 +98,11 @@ describe("Client Middleware", () => {
         expect(reqStub.hull.ship.private_settings.value).to.equal("test");
         expect(this.getStub.calledOnce).to.be.true;
         const newShip = {
-          id: "ship_id",
           private_settings: {
             value: "test2"
           }
         };
-        shipCache1.set(newShip)
+        shipCache1.set("ship_id", newShip)
           .then((arg) => {
             instance1(reqStub, {}, () => {
               expect(reqStub.hull.ship.private_settings.value).to.equal("test2");
@@ -133,12 +131,11 @@ describe("Client Middleware", () => {
         expect(reqStub.hull.ship.private_settings.value).to.equal("test1");
         expect(this.getStub.calledTwice).to.be.true;
         const newShip = {
-          id: "ship_id",
           private_settings: {
             value: "test2"
           }
         };
-        shipCache1.set(newShip)
+        shipCache1.set("ship_id", newShip)
           .then((arg) => {
             instance1(reqStub, {}, () => {
               expect(reqStub.hull.ship.private_settings.value).to.equal("test2");

--- a/tests/client-middleware-cache.js
+++ b/tests/client-middleware-cache.js
@@ -49,7 +49,7 @@ describe("Client Middleware", () => {
     this.putStub.restore();
   });
 
-  it("can take a cachingAdapter", function (done) {
+  it("should take a ShipCache", function (done) {
     const cacheAdapter = cacheManager.caching({ store: "memory", max: 100, ttl: 1/*seconds*/ });
     const shipCache = new ShipCache(cacheAdapter);
     const instance = Middleware(HullStub, { hostSecret: "secret", shipCache });
@@ -72,7 +72,7 @@ describe("Client Middleware", () => {
     });
   });
 
-  it("can disable caching", function (done) {
+  it("should allow for disabling caching", function (done) {
     const cacheAdapter = cacheManager.caching({ store: "memory", isCacheableValue: () => false });
     const shipCache = new ShipCache(cacheAdapter);
     const instance = Middleware(HullStub, { hostSecret: "secret", shipCache });

--- a/tests/client-middleware-cache.js
+++ b/tests/client-middleware-cache.js
@@ -1,0 +1,90 @@
+/* global describe, it */
+import { expect, should } from "chai";
+import sinon from "sinon";
+import cacheManager from "cache-manager";
+
+import ShipCache from "../src/ship-cache";
+import Middleware from "../src/middleware/client";
+
+class HullStub {
+  constructor() {
+    this.logger = {
+      info: console.log, //() {},
+      debug: console.log, //() {}
+    }
+  }
+  get() {}
+  put() {}
+}
+
+const reqStub = {
+  query: {
+    organization: "local",
+    secret: "secret",
+    ship: "ship_id"
+  }
+};
+
+describe("Client Middleware", () => {
+  beforeEach(function beforeEachHandler() {
+    this.getStub = sinon.stub(HullStub.prototype, "get");
+    this.getStub.onCall(0).returns(Promise.resolve({
+        id: "ship_id",
+        private_settings: {
+          value: "test"
+        }
+      }))
+      .onCall(1).returns(Promise.resolve({
+        id: "ship_id",
+        private_settings: {
+          value: "test1"
+        }
+      }));
+    this.putStub = sinon.stub(HullStub.prototype, "put");
+    this.putStub.onCall(0).returns(Promise.resolve(''));
+  });
+
+  afterEach(function afterEachHandler() {
+    this.getStub.restore();
+    this.putStub.restore();
+  });
+
+  it("can take a cachingAdapter", function (done) {
+    const cacheAdapter = cacheManager.caching({ store: "memory", max: 100, ttl: 1/*seconds*/ });
+    const instance = Middleware(HullStub, { hostSecret: "secret", cacheAdapter });
+    instance(reqStub, {}, (err) => {
+      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+      const shipCache = new ShipCache(cacheAdapter);
+      const newShip = {
+        id: "ship_id",
+        private_settings: {
+          value: "test2"
+        }
+      };
+      reqStub.hull.client.put(newShip.id, newShip)
+        .then(() => {
+          return shipCache.set(newShip);
+        })
+        .then((arg) => {
+          instance(reqStub, {}, () => {
+            expect(reqStub.hull.ship.private_settings.value).to.equal("test2");
+            expect(this.getStub.calledOnce).to.be.true;
+            done();
+          });
+        });
+    });
+  });
+
+  it("can disable caching", function (done) {
+    const cacheAdapter = cacheManager.caching({ store: "memory", isCacheableValue: () => false });
+    const instance = Middleware(HullStub, { hostSecret: "secret", cacheAdapter });
+    instance(reqStub, {}, () => {
+      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+      instance(reqStub, {}, () => {
+        expect(reqStub.hull.ship.private_settings.value).to.equal("test1");
+        expect(this.getStub.calledTwice).to.be.true;
+        done();
+      });
+    });
+  });
+});

--- a/tests/client-middleware.js
+++ b/tests/client-middleware.js
@@ -92,4 +92,19 @@ describe("Client Middleware", () => {
       });
     });
   });
+
+  it("should bust the cache for specific requests", function (done) {
+    const instance = Middleware(HullStub, { hostSecret: "secret", fetchShip: true, cacheShip: true });
+    instance(reqStub, {}, () => {
+      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+      reqStub.hull.message = {
+        Subject: "ship:update"
+      };
+      instance(reqStub, {}, () => {
+        expect(reqStub.hull.ship.private_settings.value).to.equal("test1");
+        expect(this.getStub.calledTwice).to.be.true;
+        done();
+      });
+    });
+  });
 });

--- a/tests/client-middleware.js
+++ b/tests/client-middleware.js
@@ -1,0 +1,95 @@
+/* global describe, it */
+import { expect, should } from "chai";
+import sinon from "sinon";
+
+import Middleware from "../src/middleware/client";
+
+class HullStub {
+  constructor() {
+    this.logger = {
+      info() {},
+      debug() {}
+    }
+  }
+  get() {}
+}
+
+const reqStub = {
+  query: {
+    organization: "local",
+    secret: "secret",
+    ship: "ship_id"
+  }
+};
+
+describe("Client Middleware", () => {
+  beforeEach(function beforeEachHandler() {
+    this.getStub = sinon.stub(HullStub.prototype, "get");
+    this.getStub.onCall(0).returns(Promise.resolve({
+        id: "ship_id",
+        private_settings: {
+          value: "test"
+        }
+      }))
+      .onCall(1).returns(Promise.resolve({
+        id: "ship_id",
+        private_settings: {
+          value: "test1"
+        }
+      }));
+  });
+
+  afterEach(function afterEachHandler() {
+    this.getStub.restore();
+  });
+
+  it("needs hostSecret option", () => {
+    expect(() => {
+      return Middleware(HullStub);
+    }).to.throw(TypeError);
+
+    expect(() => {
+      return Middleware(HullStub, { hostSecret: "secret" });
+    }).to.not.throw(TypeError);
+  });
+
+  it("should return a middleware function", () => {
+    const instance = Middleware(HullStub, { hostSecret: "secret" });
+    const next = sinon.spy();
+    instance({}, {}, next);
+    expect(next.calledOnce).to.be.true;
+  });
+
+  it("should fetch a ship", function (done) {
+    const instance = Middleware(HullStub, { hostSecret: "secret", fetchShip: true });
+    instance(reqStub, {}, () => {
+      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+      expect(this.getStub.calledOnce).to.be.true;
+      done();
+    });
+  });
+
+  it("should fetch ship every time without caching", function (done) {
+    const instance = Middleware(HullStub, { hostSecret: "secret", fetchShip: true, cacheShip: false });
+    instance(reqStub, {}, () => {
+      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+      instance(reqStub, {}, () => {
+        expect(reqStub.hull.ship.private_settings.value).to.equal("test1");
+        expect(this.getStub.calledTwice).to.be.true;
+        done();
+      });
+    });
+  });
+
+  it("should store a ship in cache", function (done) {
+    const instance = Middleware(HullStub, { hostSecret: "secret", fetchShip: true, cacheShip: true });
+    instance(reqStub, {}, () => {
+      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+      instance(reqStub, {}, () => {
+        expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+        expect(this.getStub.calledOnce).to.be.true;
+        done();
+      });
+    });
+  });
+});

--- a/tests/fixtures/sns-messages/ship-update.json
+++ b/tests/fixtures/sns-messages/ship-update.json
@@ -1,0 +1,5 @@
+{
+  "Type": "Notification",
+  "Subject": "ship:update",
+  "Message": "{}"
+}

--- a/tests/fixtures/sns-messages/user-report.json
+++ b/tests/fixtures/sns-messages/user-report.json
@@ -1,0 +1,5 @@
+{
+  "Type": "Notification",
+  "Subject": "user:update",
+  "Message": "{}"
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,6 @@
 require("babel-register")({ presets: ["es2015", "stage-0"] });
 require("./client-middleware");
 require("./client-middleware-cache");
+require("./notif-handler");
 require("./traits-tests");
 require("./firehose-batcher-tests");

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,4 +1,5 @@
 require("babel-register")({ presets: ["es2015", "stage-0"] });
 require("./client-middleware");
+require("./client-middleware-cache");
 require("./traits-tests");
 require("./firehose-batcher-tests");

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,4 @@
 require("babel-register")({ presets: ["es2015", "stage-0"] });
+require("./client-middleware");
 require("./traits-tests");
 require("./firehose-batcher-tests");

--- a/tests/notif-handler.js
+++ b/tests/notif-handler.js
@@ -131,12 +131,11 @@ describe("NotifHandler", () => {
       post({ port, body: userUpdate })
         .then(() => {
           const newShip = {
-            id: "ship_id",
             private_settings: {
               value: "test2"
             }
           };
-          return shipCache.set(newShip);
+          return shipCache.set("ship_id", newShip);
         })
         .then(() => {
           return post({ port, body: userUpdate });

--- a/tests/notif-handler.js
+++ b/tests/notif-handler.js
@@ -1,0 +1,152 @@
+/* global describe, it */
+import http from "http";
+import { expect, should } from "chai";
+import sinon from "sinon";
+import express from "express";
+import Promise from "bluebird";
+import CacheManager from "cache-manager";
+
+import shipUpdate from "./fixtures/sns-messages/ship-update.json";
+import userUpdate from "./fixtures/sns-messages/user-report.json";
+import NotifHandler from "../src/notif-handler";
+import ShipCache from "../src/ship-cache";
+
+class HullStub {
+  constructor() {
+    this.logger = {
+      info() {},
+      debug() {}
+    }
+  }
+  get() {}
+}
+
+const reqStub = {
+  url: "http://localhost/",
+  body: '{"test":"test"}',
+  query: {
+    organization: "local",
+    secret: "secret",
+    ship: "ship_id"
+  }
+};
+
+function post({ port, body }) {
+  return Promise.fromCallback(function(callback) {
+    const client = http.request({ path: "/notify?organization=local&secret=secret&ship=ship_id", method: 'POST', port })
+    client.end(JSON.stringify(body))
+    client.on("response", () => callback());
+  });
+}
+
+describe("NotifHandler", () => {
+  beforeEach(function beforeEachHandler() {
+    this.getStub = sinon.stub(HullStub.prototype, "get");
+    this.getStub.onCall(0).returns(Promise.resolve({
+        id: "ship_id",
+        private_settings: {
+          value: "test"
+        }
+      }))
+      .onCall(1).returns(Promise.resolve({
+        id: "ship_id",
+        private_settings: {
+          value: "test1"
+        }
+      }));
+  });
+
+  afterEach(function afterEachHandler() {
+    this.getStub.restore();
+  });
+
+  it("should bust the middleware at ship:update event", (done) => {
+    const handler = sinon.spy();
+    const app = express();
+    const notifHandler = NotifHandler(HullStub, {
+      handlers: {
+        "ship:update": handler
+      },
+      hostSecret: "test"
+    });
+    app.post("/notify", notifHandler);
+    const server = app.listen(() => {
+      const port = server.address().port;
+
+      post({ port, body: shipUpdate })
+        .then(() => {
+          return post({ port, body: shipUpdate })
+        })
+        .then(() => {
+          expect(handler.calledTwice).to.be.ok;
+          expect(handler.getCall(0).args[1].ship.private_settings.value).to.equal("test");
+          expect(handler.getCall(1).args[1].ship.private_settings.value).to.equal("test1");
+          done();
+        });
+    });
+  });
+
+  it("should not bust the middleware at different events", (done) => {
+    const handler = sinon.spy();
+    const app = express();
+    const notifHandler = NotifHandler(HullStub, {
+      handlers: {
+        "user:update": handler
+      },
+      hostSecret: "test"
+    });
+    app.post("/notify", notifHandler);
+    const server = app.listen(() => {
+      const port = server.address().port;
+
+      post({ port, body: userUpdate })
+        .then(() => {
+          return post({ port, body: userUpdate })
+        })
+        .then(() => {
+          expect(handler.calledTwice).to.be.ok;
+          expect(handler.getCall(0).args[1].ship.private_settings.value).to.equal("test");
+          expect(handler.getCall(1).args[1].ship.private_settings.value).to.equal("test");
+          done();
+        });
+    });
+  });
+
+  it("should allow for ShipCache sharing", (done) => {
+    const handler = sinon.spy();
+    const cacheAdapter = CacheManager.caching({ store: "memory", max: 100, ttl: 1/*seconds*/ });
+    const shipCache = new ShipCache(cacheAdapter);
+    const app = express();
+    const notifHandler = NotifHandler(HullStub, {
+      handlers: {
+        "user:update": handler
+      },
+      hostSecret: "test",
+      shipCache
+    });
+    app.post("/notify", notifHandler);
+    const server = app.listen(() => {
+      const port = server.address().port;
+
+      post({ port, body: userUpdate })
+        .then(() => {
+          const newShip = {
+            id: "ship_id",
+            private_settings: {
+              value: "test2"
+            }
+          };
+          return shipCache.set(newShip);
+        })
+        .then(() => {
+          return post({ port, body: userUpdate });
+        })
+        .then(() => {
+          expect(handler.calledTwice).to.be.ok;
+          expect(handler.getCall(0).args[1].ship.private_settings.value).to.equal("test");
+          expect(handler.getCall(1).args[1].ship.private_settings.value).to.equal("test2");
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
1. adds basic tests to the middleware - all pass on present master
2. introduces a `ShipCache` which is a wrapper over cache-manager
3. migrates the Hull client middleware to the ShipCache for caching
  - this allows ttl
  - and allows application to modify the cache - as shown in tests:
```
hull.client.put(newShip.id, newShip)
     .then(() => {
          return shipCache.set(newShip);
     })
```