### PR TITLE
Move signing cache key to ship-cache module

### DIFF
--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -35,7 +35,7 @@ function shipCacheFactory(cacheShip) {
     ttl: 10/*seconds*/
   });
 
-  return new ShipCache(cacheAdapter, process.env.SHIP_CACHE_NAMESPACE);
+  return new ShipCache(cacheAdapter);
 }
 
 

--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -26,7 +26,7 @@ function parseToken(token, secret) {
   }
 }
 
-function shipCacheFactory(cacheShip, client) {
+function shipCacheFactory(cacheShip) {
   // setup default CacheManager
   const cacheAdapter = CacheManager.caching({
     store: 'memory',
@@ -35,14 +35,13 @@ function shipCacheFactory(cacheShip, client) {
     ttl: 10/*seconds*/
   });
 
-  return new ShipCache(cacheAdapter, client);
+  return new ShipCache(cacheAdapter);
 }
 
 
 module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, shipCache = null, requireCredentials = true }) {
-
   if (shipCache === null) {
-    shipCache = shipCacheFactory(cacheShip, client);
+    shipCache = shipCacheFactory(cacheShip);
   }
 
   function getCurrentShip(id, client, bust) {

--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -35,7 +35,7 @@ function shipCacheFactory(cacheShip) {
     ttl: 10/*seconds*/
   });
 
-  return new ShipCache(cacheAdapter);
+  return new ShipCache(cacheAdapter, process.env.SHIP_CACHE_NAMESPACE);
 }
 
 

--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -41,6 +41,10 @@ function shipCacheFactory(cacheShip, client) {
 
 module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, shipCache = null, requireCredentials = true }) {
 
+  if (shipCache === null) {
+    shipCache = shipCacheFactory(cacheShip, client);
+  }
+
   function getCurrentShip(id, client, bust) {
 
     return (() => {
@@ -70,10 +74,7 @@ module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetc
       const { organization, ship: id, secret } = config;
       if (organization && id && secret) {
         const client = req.hull.client = new Client({ id, secret, organization });
-
-        if (shipCache === null) {
-          shipCache = shipCacheFactory(cacheShip, client);
-        }
+        shipCache.setClient(client);
 
         req.hull.token = jwt.encode(config, hostSecret);
         if (fetchShip) {

--- a/src/ship-cache.js
+++ b/src/ship-cache.js
@@ -12,11 +12,14 @@ export default class ShipCache {
    * @param {Object} cache instance of cache-manager
    * @param {String} namespace name of the namespace
    */
-  constructor(cache, namespace) {
+  constructor(cache, namespace = "global") {
     this.cache = cache;
-    this.namespace
+    this.namespace = namespace;
   }
 
+  /**
+   * @param {Object} client Hull Client
+   */
   setClient(client) {
     this.client = client;
   }
@@ -27,7 +30,7 @@ export default class ShipCache {
    */
   getShipKey(id) {
     const { secret, organization } = this.client.configuration();
-    return jwt.encode({ sub: id, iss: organization }, secret);
+    return this.namespace + '_' + jwt.encode({ sub: id, iss: organization }, secret);
   }
 
   /**

--- a/src/ship-cache.js
+++ b/src/ship-cache.js
@@ -12,8 +12,12 @@ export default class ShipCache {
    * @param {Object} cache instance of cache-manager
    * @param {String} namespace name of the namespace
    */
-  constructor(cache, client) {
+  constructor(cache, namespace) {
     this.cache = cache;
+    this.namespace
+  }
+
+  setClient(client) {
     this.client = client;
   }
 

--- a/src/ship-cache.js
+++ b/src/ship-cache.js
@@ -10,14 +10,9 @@ export default class ShipCache {
 
   /**
    * @param {Object} cache instance of cache-manager
-   * @param {String} namespace name of the namespace
    */
-  constructor(cache, namespace) {
-    if (!namespace) {
-      throw new Error("Namespace is required");
-    }
+  constructor(cache) {
     this.cache = cache;
-    this.namespace = namespace;
   }
 
   /**

--- a/src/ship-cache.js
+++ b/src/ship-cache.js
@@ -1,3 +1,5 @@
+import jwt from "jwt-simple";
+
 /**
  * This is a wrapper over https://github.com/BryanDonovan/node-cache-manager
  * to manage ship cache storage.
@@ -10,9 +12,9 @@ export default class ShipCache {
    * @param {Object} cache instance of cache-manager
    * @param {String} namespace name of the namespace
    */
-  constructor(cache, namespace) {
+  constructor(cache, client) {
     this.cache = cache;
-    this.namespace = namespace || "global";
+    this.client = client;
   }
 
   /**
@@ -20,7 +22,8 @@ export default class ShipCache {
    * @return {String}
    */
   getShipKey(id) {
-    return `${this.namespace}_ship-${id}`;
+    const { secret, organization } = this.client.configuration();
+    return jwt.encode({ sub: id, iss: organization }, secret);
   }
 
   /**

--- a/src/ship-cache.js
+++ b/src/ship-cache.js
@@ -3,8 +3,7 @@ import jwt from "jwt-simple";
 /**
  * This is a wrapper over https://github.com/BryanDonovan/node-cache-manager
  * to manage ship cache storage.
- * It is responsible for handling cache key for every ship,
- * and support namespaces.
+ * It is responsible for handling cache key for every ship.
  */
 export default class ShipCache {
 
@@ -28,7 +27,7 @@ export default class ShipCache {
    */
   getShipKey(id) {
     const { secret, organization } = this.client.configuration();
-    return this.namespace + '_' + jwt.encode({ sub: id, iss: organization }, secret);
+    return jwt.encode({ sub: id, iss: organization }, secret);
   }
 
   /**

--- a/src/ship-cache.js
+++ b/src/ship-cache.js
@@ -12,7 +12,10 @@ export default class ShipCache {
    * @param {Object} cache instance of cache-manager
    * @param {String} namespace name of the namespace
    */
-  constructor(cache, namespace = "global") {
+  constructor(cache, namespace) {
+    if (!namespace) {
+      throw new Error("Namespace is required");
+    }
     this.cache = cache;
     this.namespace = namespace;
   }

--- a/tests/client-middleware-cache.js
+++ b/tests/client-middleware-cache.js
@@ -57,7 +57,7 @@ describe("Client Middleware", () => {
 
   it("should take a ShipCache", function (done) {
     const cacheAdapter = cacheManager.caching({ store: "memory", max: 100, ttl: 1/*seconds*/ });
-    const shipCache = new ShipCache(cacheAdapter);
+    const shipCache = new ShipCache(cacheAdapter, "test");
     const instance = Middleware(HullStub, { hostSecret: "secret", shipCache });
     instance(reqStub, {}, (err) => {
       expect(reqStub.hull.ship.private_settings.value).to.equal("test");
@@ -79,7 +79,7 @@ describe("Client Middleware", () => {
 
   it("should allow for disabling caching", function (done) {
     const cacheAdapter = cacheManager.caching({ store: "memory", isCacheableValue: () => false });
-    const shipCache = new ShipCache(cacheAdapter);
+    const shipCache = new ShipCache(cacheAdapter, "test");
     const instance = Middleware(HullStub, { hostSecret: "secret", shipCache });
     instance(reqStub, {}, () => {
       expect(reqStub.hull.ship.private_settings.value).to.equal("test");
@@ -91,10 +91,10 @@ describe("Client Middleware", () => {
     });
   });
 
-  it("should share the cache using the same adapter", function (done) {
+  it("should share the cache using the same adapter and namespace", function (done) {
     const cacheAdapter = cacheManager.caching({ store: "memory", max: 100, ttl: 1/*seconds*/ });
-    const shipCache1 = new ShipCache(cacheAdapter);
-    const shipCache2 = new ShipCache(cacheAdapter);
+    const shipCache1 = new ShipCache(cacheAdapter, "test");
+    const shipCache2 = new ShipCache(cacheAdapter, "test");
     const instance1 = Middleware(HullStub, { hostSecret: "secret", shipCache: shipCache1 });
     const instance2 = Middleware(HullStub, { hostSecret: "secret", shipCache: shipCache2 });
     instance1(reqStub, {}, (err) => {

--- a/tests/client-middleware-cache.js
+++ b/tests/client-middleware-cache.js
@@ -57,7 +57,7 @@ describe("Client Middleware", () => {
 
   it("should take a ShipCache", function (done) {
     const cacheAdapter = cacheManager.caching({ store: "memory", max: 100, ttl: 1/*seconds*/ });
-    const shipCache = new ShipCache(cacheAdapter, "test");
+    const shipCache = new ShipCache(cacheAdapter);
     const instance = Middleware(HullStub, { hostSecret: "secret", shipCache });
     instance(reqStub, {}, (err) => {
       expect(reqStub.hull.ship.private_settings.value).to.equal("test");
@@ -79,7 +79,7 @@ describe("Client Middleware", () => {
 
   it("should allow for disabling caching", function (done) {
     const cacheAdapter = cacheManager.caching({ store: "memory", isCacheableValue: () => false });
-    const shipCache = new ShipCache(cacheAdapter, "test");
+    const shipCache = new ShipCache(cacheAdapter);
     const instance = Middleware(HullStub, { hostSecret: "secret", shipCache });
     instance(reqStub, {}, () => {
       expect(reqStub.hull.ship.private_settings.value).to.equal("test");
@@ -93,8 +93,8 @@ describe("Client Middleware", () => {
 
   it("should share the cache using the same adapter and namespace", function (done) {
     const cacheAdapter = cacheManager.caching({ store: "memory", max: 100, ttl: 1/*seconds*/ });
-    const shipCache1 = new ShipCache(cacheAdapter, "test");
-    const shipCache2 = new ShipCache(cacheAdapter, "test");
+    const shipCache1 = new ShipCache(cacheAdapter);
+    const shipCache2 = new ShipCache(cacheAdapter);
     const instance1 = Middleware(HullStub, { hostSecret: "secret", shipCache: shipCache1 });
     const instance2 = Middleware(HullStub, { hostSecret: "secret", shipCache: shipCache2 });
     instance1(reqStub, {}, (err) => {
@@ -116,39 +116,6 @@ describe("Client Middleware", () => {
               instance2(reqStub, {}, () => {
                 expect(reqStub.hull.ship.private_settings.value).to.equal("test2");
                 expect(this.getStub.calledOnce).to.be.true;
-                done();
-              });
-            });
-          });
-      });
-    });
-  });
-
-  it("should support different namespaces when using the same adapter", function (done) {
-    const cacheAdapter = cacheManager.caching({ store: "memory", max: 100, ttl: 1/*seconds*/ });
-    const shipCache1 = new ShipCache(cacheAdapter, "namespace1");
-    const shipCache2 = new ShipCache(cacheAdapter, "namespace2");
-    const instance1 = Middleware(HullStub, { hostSecret: "secret", shipCache: shipCache1 });
-    const instance2 = Middleware(HullStub, { hostSecret: "secret", shipCache: shipCache2 });
-    instance1(reqStub, {}, (err) => {
-      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
-      expect(this.getStub.calledOnce).to.be.true;
-      instance2(reqStub, {}, () => {
-        expect(reqStub.hull.ship.private_settings.value).to.equal("test1");
-        expect(this.getStub.calledTwice).to.be.true;
-        const newShip = {
-          private_settings: {
-            value: "test2"
-          }
-        };
-        shipCache1.set("ship_id", newShip)
-          .then((arg) => {
-            instance1(reqStub, {}, () => {
-              expect(reqStub.hull.ship.private_settings.value).to.equal("test2");
-              expect(this.getStub.calledTwice).to.be.true;
-              instance2(reqStub, {}, () => {
-                expect(reqStub.hull.ship.private_settings.value).to.equal("test1");
-                expect(this.getStub.calledTwice).to.be.true;
                 done();
               });
             });

--- a/tests/client-middleware.js
+++ b/tests/client-middleware.js
@@ -11,6 +11,12 @@ class HullStub {
       debug() {}
     }
   }
+  configuration() {
+    return {
+      secret: "secret",
+      organization: "local"
+    };
+  }
   get() {}
 }
 

--- a/tests/client-middleware.js
+++ b/tests/client-middleware.js
@@ -4,6 +4,7 @@ import sinon from "sinon";
 
 import Middleware from "../src/middleware/client";
 
+process.env.SHIP_CACHE_NAMESPACE = "test";
 class HullStub {
   constructor() {
     this.logger = {

--- a/tests/firehose-batcher-tests.js
+++ b/tests/firehose-batcher-tests.js
@@ -1,4 +1,5 @@
 /* global describe, it */
+import Promise from "bluebird";
 
 import Batcher from "../src/firehose-batcher";
 import Hull from "../src/client";
@@ -30,6 +31,7 @@ describe("Batch", () => {
           expect(batch[0].headers['Hull-Access-Token']).to.eq("456");
           done();
         }
+        return Promise.resolve();
       }
 
       const batch1 = Batcher.getInstance({ ...config, accessToken: "123" }, handler);


### PR DESCRIPTION
The `ShipCache` have it's own method to generate cacheKey for ships.
Idea of signing the ship id with secret and organization is good, so I've moved it to the `ShipCache` module.