### PR TITLE
Add `additionalConfig` to the HullMiddleware

### DIFF
--- a/src/firehose-batcher.js
+++ b/src/firehose-batcher.js
@@ -45,7 +45,7 @@ class FirehoseBatcher {
   constructor(config, handler) {
     this.handler = handler || defaultHandler;
     this.flushAt = Math.max(config.flushAt, 1) || 50;
-    this.flushAfter = config.flushAfter || 10000;
+    this.flushAfter = config.flushAfter || 1000;
     this.config = new Configuration(_.omit(config, "userId", "accessToken", "sudo"));
     this.queue = [];
   }

--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -40,7 +40,7 @@ function shipCacheFactory(cacheShip) {
 }
 
 
-module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, shipCache = null, requireCredentials = true, additionalConfig = {} }) {
+module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, shipCache = null, requireCredentials = true, clientConfig = {} }) {
   if (shipCache === null) {
     shipCache = shipCacheFactory(cacheShip);
   }
@@ -73,7 +73,7 @@ module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetc
       const { message, config } = req.hull;
       const { organization, ship: id, secret } = config;
       if (organization && id && secret) {
-        const client = req.hull.client = new Client(_.merge({ id, secret, organization }, additionalConfig));
+        const client = req.hull.client = new Client(_.merge({ id, secret, organization }, clientConfig));
         shipCache.setClient(client);
 
         req.hull.token = jwt.encode(config, hostSecret);

--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import jwt from "jwt-simple";
 import CacheManager from "cache-manager";
 import ShipCache from "../ship-cache";
@@ -39,7 +40,7 @@ function shipCacheFactory(cacheShip) {
 }
 
 
-module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, shipCache = null, requireCredentials = true }) {
+module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetchShip = true, cacheShip = true, shipCache = null, requireCredentials = true, additionalConfig = {} }) {
   if (shipCache === null) {
     shipCache = shipCacheFactory(cacheShip);
   }
@@ -72,7 +73,7 @@ module.exports = function hullClientMiddlewareFactory(Client, { hostSecret, fetc
       const { message, config } = req.hull;
       const { organization, ship: id, secret } = config;
       if (organization && id && secret) {
-        const client = req.hull.client = new Client({ id, secret, organization });
+        const client = req.hull.client = new Client(_.merge({ id, secret, organization }, additionalConfig));
         shipCache.setClient(client);
 
         req.hull.token = jwt.encode(config, hostSecret);

--- a/src/notif-handler.js
+++ b/src/notif-handler.js
@@ -144,7 +144,7 @@ function processHandlers(handlers) {
 }
 
 
-module.exports = function NotifHandler(Client, { handlers = [], hostSecret, groupTraits, onSubscribe, shipCache = null }) {
+module.exports = function NotifHandler(Client, { handlers = [], hostSecret, groupTraits, onSubscribe, shipCache = null, clientConfig = {} }) {
   const _handlers = {};
   const app = connect();
 
@@ -170,7 +170,7 @@ module.exports = function NotifHandler(Client, { handlers = [], hostSecret, grou
     enforceValidation: false,
     groupTraits: groupTraits !== false
   }));
-  app.use(hullClient(Client, { hostSecret, fetchShip: true, cacheShip: true, shipCache }));
+  app.use(hullClient(Client, { hostSecret, fetchShip: true, cacheShip: true, shipCache, clientConfig }));
   app.use(processHandlers(_handlers));
   app.use((req, res) => { res.end("ok"); });
 

--- a/tests/client-middleware.js
+++ b/tests/client-middleware.js
@@ -98,9 +98,9 @@ describe("Client Middleware", () => {
     });
   });
 
-  it("should take an optional `additionalConfig` param", function (done) {
+  it("should take an optional `clientConfig` param", function (done) {
     const hullSpy = sinon.stub() ;
-    const instance = Middleware(hullSpy, { hostSecret: "secret", additionalConfig: { flushAt: 123 } })
+    const instance = Middleware(hullSpy, { hostSecret: "secret", clientConfig: { flushAt: 123 } })
     instance(this.reqStub, {}, () => {
       expect(hullSpy.calledWith({
         id: "ship_id",

--- a/tests/client-middleware.js
+++ b/tests/client-middleware.js
@@ -5,16 +5,15 @@ import sinon from "sinon";
 import Middleware from "../src/middleware/client";
 import HullStub from "./support/hull-stub";
 
-const reqStub = {
-  query: {
-    organization: "local",
-    secret: "secret",
-    ship: "ship_id"
-  }
-};
-
 describe("Client Middleware", () => {
   beforeEach(function beforeEachHandler() {
+    this.reqStub = {
+      query: {
+        organization: "local",
+        secret: "secret",
+        ship: "ship_id"
+      }
+    };
     this.getStub = sinon.stub(HullStub.prototype, "get");
     this.getStub.onCall(0).returns(Promise.resolve({
         id: "ship_id",
@@ -53,8 +52,8 @@ describe("Client Middleware", () => {
 
   it("should fetch a ship", function (done) {
     const instance = Middleware(HullStub, { hostSecret: "secret", fetchShip: true });
-    instance(reqStub, {}, () => {
-      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+    instance(this.reqStub, {}, () => {
+      expect(this.reqStub.hull.ship.private_settings.value).to.equal("test");
       expect(this.getStub.calledOnce).to.be.true;
       done();
     });
@@ -62,10 +61,10 @@ describe("Client Middleware", () => {
 
   it("should fetch ship every time without caching", function (done) {
     const instance = Middleware(HullStub, { hostSecret: "secret", fetchShip: true, cacheShip: false });
-    instance(reqStub, {}, () => {
-      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
-      instance(reqStub, {}, () => {
-        expect(reqStub.hull.ship.private_settings.value).to.equal("test1");
+    instance(this.reqStub, {}, () => {
+      expect(this.reqStub.hull.ship.private_settings.value).to.equal("test");
+      instance(this.reqStub, {}, () => {
+        expect(this.reqStub.hull.ship.private_settings.value).to.equal("test1");
         expect(this.getStub.calledTwice).to.be.true;
         done();
       });
@@ -74,10 +73,10 @@ describe("Client Middleware", () => {
 
   it("should store a ship in cache", function (done) {
     const instance = Middleware(HullStub, { hostSecret: "secret", fetchShip: true, cacheShip: true });
-    instance(reqStub, {}, () => {
-      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
-      instance(reqStub, {}, () => {
-        expect(reqStub.hull.ship.private_settings.value).to.equal("test");
+    instance(this.reqStub, {}, () => {
+      expect(this.reqStub.hull.ship.private_settings.value).to.equal("test");
+      instance(this.reqStub, {}, () => {
+        expect(this.reqStub.hull.ship.private_settings.value).to.equal("test");
         expect(this.getStub.calledOnce).to.be.true;
         done();
       });
@@ -86,16 +85,30 @@ describe("Client Middleware", () => {
 
   it("should bust the cache for specific requests", function (done) {
     const instance = Middleware(HullStub, { hostSecret: "secret", fetchShip: true, cacheShip: true });
-    instance(reqStub, {}, () => {
-      expect(reqStub.hull.ship.private_settings.value).to.equal("test");
-      reqStub.hull.message = {
+    instance(this.reqStub, {}, () => {
+      expect(this.reqStub.hull.ship.private_settings.value).to.equal("test");
+      this.reqStub.hull.message = {
         Subject: "ship:update"
       };
-      instance(reqStub, {}, () => {
-        expect(reqStub.hull.ship.private_settings.value).to.equal("test1");
+      instance(this.reqStub, {}, () => {
+        expect(this.reqStub.hull.ship.private_settings.value).to.equal("test1");
         expect(this.getStub.calledTwice).to.be.true;
         done();
       });
+    });
+  });
+
+  it("should take an optional `additionalConfig` param", function (done) {
+    const hullSpy = sinon.stub() ;
+    const instance = Middleware(hullSpy, { hostSecret: "secret", additionalConfig: { flushAt: 123 } })
+    instance(this.reqStub, {}, () => {
+      expect(hullSpy.calledWith({
+        id: "ship_id",
+        secret: "secret",
+        organization: "local",
+        flushAt: 123
+      })).to.be.true;
+      done();
     });
   });
 });

--- a/tests/notif-handler.js
+++ b/tests/notif-handler.js
@@ -140,4 +140,26 @@ describe("NotifHandler", () => {
         });
     });
   });
+
+  it("should take an optional `clientConfig` param", function (done) {
+    const hullSpy = sinon.stub() ;
+    const notifHandler = NotifHandler(hullSpy, { hostSecret: "secret", clientConfig: { flushAt: 123 } })
+    const app = express();
+
+    app.post("/notify", notifHandler);
+    const server = app.listen(() => {
+      const port = server.address().port;
+
+      post({ port, body: userUpdate })
+      .then(() => {
+        expect(hullSpy.calledWith({
+          id: "ship_id",
+          secret: "secret",
+          organization: "local",
+          flushAt: 123
+        })).to.be.true;
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
An option to pass additional config to the `hullClientMiddlewareFactory`.
Do we need to adjust this place:
https://github.com/hull/hull-node/blob/master/src/client.js#L58

otherwise it will add config props like `flushAt` and `flushAfter` to the log line.