### PR TITLE
Fix callback url and the verifyAccount callback

### DIFF
--- a/src/oauth-handler.js
+++ b/src/oauth-handler.js
@@ -33,6 +33,11 @@ export default function oauth(Client, {
   function getURL(req, url, qs = { token: req.hull.token }) {
     return `https://${req.hostname}${req.baseUrl}${url}?${querystring.stringify(qs)}`;
   }
+
+  function getUrlWithoutToken(req, url) {
+    return `https://${req.hostname}${req.baseUrl}${url}`;
+  }
+
   function getURLs(req) {
     return {
       login: getURL(req, LOGIN_URL),
@@ -54,8 +59,8 @@ export default function oauth(Client, {
     done(null, user);
   });
 
-  const strategy = new Strategy({ ...options, passReqToCallback: true }, function verifyAccount(req, accessToken, refreshToken, params, profile, done) {
-    done(undefined, { accessToken, refreshToken, params, profile });
+  const strategy = new Strategy({ ...options, passReqToCallback: true }, function verifyAccount(req, accessToken, refreshToken, profile, done) {
+    done(undefined, { accessToken, refreshToken, profile });
   });
 
   passport.use(strategy);
@@ -76,7 +81,7 @@ export default function oauth(Client, {
   function authorize(req, res, next) {
     passport.authorize(strategy.name, {
       ...req.authParams,
-      callbackURL: getURL(req, CALLBACK_URL)
+      callbackURL: getUrlWithoutToken(req, CALLBACK_URL)
     })(req, res, next);
   }
 


### PR DESCRIPTION
1. Some oAuth services like Stripe or Intercom are very strict about the callback url - it has to be exactly the same as in settings - so adding the token to the callback url broke the flow.
The handler also pass the token in `state` param, so removing token was a fix here - at least for Stripe and Intercom. Need to verify for hubspot.

2. The `verifyAccount` signature is different for the strategies like this:
https://github.com/intercom/passport-intercom
https://github.com/mathisonian/passport-stripe
https://www.npmjs.com/package/passport-mailchimp
Adjusted