### PR TITLE
Adds user -> account linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
+# 0.11.0-beta.3
+* fix the `requestExtract` handler - allow passing `path` param
+* fix the `.asUser()` and `.asAccount()` to return `traits` and `track`
+* adds `.asUser().account()` method
+
 # 0.11.0-beta.2
 * Reorganize the utils/helpers
 * Introduce hull.as() create option
 * Upgrade raven API and add default exit handler
 * Combine notifHandler and batchHandler
 * Automatically filter out users using segment filter on user:update and NOT on batch actions
+* Renames `hull().as()` method to `hull().asUser()`
+* Adds initial support for accounts
 
 # 0.11.0-beta.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hull",
-  "version": "0.11.0-beta.2",
+  "version": "0.11.0-beta.3",
   "description": "A Node.js client for hull.io",
   "main": "lib",
   "repository": {

--- a/src/client.js
+++ b/src/client.js
@@ -79,7 +79,7 @@ const Client = function Client(config = {}) {
   // Check conditions on when to create a "user client" or an "org client".
   // When to pass org scret or not
 
-  if (config.userId || config.accessToken) {
+  if (config.userClaim || config.accountClaim || config.accessToken) {
     this.traits = (traits, context = {}) => {
       // Quick and dirty way to add a source prefix to all traits we want in.
       const source = context.source;
@@ -114,19 +114,28 @@ const Client = function Client(config = {}) {
         }
       });
     };
+
+    if (config.userClaim) {
+      this.account = (accountClaim = {}) => {
+        if (!accountClaim) {
+          return new Client({ ...config, subjectType: "account" });
+        }
+        return new Client({ ...config, subjectType: "account", accountClaim });
+      };
+    }
   } else {
-    this.asUser = (userClaim, additionalClaims) => {
+    this.asUser = (userClaim, additionalClaims = {}) => {
       if (!userClaim) {
         throw new Error("User Claims was not defined when calling hull.asUser()");
       }
-      return new Client({ ...config, userClaim, additionalClaims });
+      return new Client({ ...config, subjectType: "user", userClaim, additionalClaims });
     };
 
-    this.asAccount = (accountClaim, additionalClaims) => {
+    this.asAccount = (accountClaim, additionalClaims = {}) => {
       if (!accountClaim) {
         throw new Error("Account Claims was not defined when calling hull.asAccount()");
       }
-      return new Client({ ...config, accountClaim, additionalClaims });
+      return new Client({ ...config, subjectType: "account", accountClaim, additionalClaims });
     };
   }
 };

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -76,7 +76,7 @@ class Configuration {
 
     if (config.userClaim || config.accountClaim) {
       assertClaimValidity("user", config.userClaim, ["id", "email", "external_id", "anonymous_id"]);
-      assertClaimValidity("account", config.accountClaim, ["id", "external_id", "name", "domain"]);
+      assertClaimValidity("account", config.accountClaim, ["id", "external_id", "domain"]);
       const accessToken = crypto.lookupToken(config, config.subjectType, {
         user: config.userClaim,
         account: config.accountClaim

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -49,7 +49,7 @@ const VALID_PROPS = {
 };
 
 /**
- * make sure that provided "identity claim"
+ * make sure that provided "identity claim" is valid
  * @param  {String} type          "user" or "account"
  * @param  {String|Object} object identity claim
  * @param  {Array} requiredFields fields which are required if the passed

--- a/src/helpers/request-extract.js
+++ b/src/helpers/request-extract.js
@@ -3,7 +3,7 @@
  * @param  {Object} options
  * @return {Promise}
  */
-export default function requestExtract(ctx, { segment = null, fields = [] } = {}) {
+export default function requestExtract(ctx, { segment = null, path, fields = [] } = {}) {
   const { client, hostname } = ctx;
-  return client.utils.extract.request({ hostname, segment, fields });
+  return client.utils.extract.request({ hostname, segment, path, fields });
 }

--- a/tests/client-tests.js
+++ b/tests/client-tests.js
@@ -28,7 +28,7 @@ describe("Hull", () => {
     it("should return scoped client with traits and track methods", () => {
       const hull = new Hull({ id: "562123b470df84b740000042", secret: "1234", organization: "test" });
 
-      const scopedAccount = hull.asAccount({ name: "Hull" });
+      const scopedAccount = hull.asAccount({ domain: "hull.io" });
       const scopedUser = hull.asUser("1234");
 
       expect(scopedAccount).to.has.property("traits")
@@ -67,21 +67,24 @@ describe("Hull", () => {
         .that.eql("123456");
     });
 
-    it("should allow to pass account name as an object property", () => {
+    it("should allow to pass account domain as an object property", () => {
       const hull = new Hull({ id: "562123b470df84b740000042", secret: "1234", organization: "test" });
 
-      const scoped = hull.asAccount({ name: "Hull" });
+      const scoped = hull.asAccount({ domain: "hull.io" });
       const scopedConfig = scoped.configuration();
       const scopedJwtClaims = jwt.decode(scopedConfig.accessToken, scopedConfig.secret);
       expect(scopedJwtClaims)
         .to.have.property("io.hull.asAccount")
-        .that.eql({ name: "Hull" });
+        .that.eql({ domain: "hull.io" });
+      expect(scopedJwtClaims)
+        .to.have.property("io.hull.subjectType")
+        .that.eql("account");
     });
 
     it("should allow to link user to an account", () => {
       const hull = new Hull({ id: "562123b470df84b740000042", secret: "1234", organization: "test" });
 
-      const scoped = hull.asUser({ email: "foo@bar.com" }).account({ name: "Hull" });
+      const scoped = hull.asUser({ email: "foo@bar.com" }).account({ domain: "hull.io" });
       const scopedJwtClaims = jwt.decode(scoped.configuration().accessToken, scoped.configuration().secret);
 
       expect(scopedJwtClaims)
@@ -89,13 +92,13 @@ describe("Hull", () => {
         .that.eql("account");
       expect(scopedJwtClaims)
         .to.have.property("io.hull.asAccount")
-        .that.eql({ name: "Hull" });
+        .that.eql({ domain: "hull.io" });
       expect(scopedJwtClaims)
         .to.have.property("io.hull.asUser")
         .that.eql({ email: "foo@bar.com" });
     });
 
-    it("should allow to link user to an existing account", () => {
+    it("should allow to resolve an existing account user is linked to", () => {
       const hull = new Hull({ id: "562123b470df84b740000042", secret: "1234", organization: "test" });
 
       const scoped = hull.asUser({ email: "foo@bar.com" }).account();


### PR DESCRIPTION
* fix the `requestExtract` handler - allow passing `path` param
* fix the `.asUser()` and `.asAccount()` to return `traits` and `track`
* adds `.asUser().account()` method