### PR TITLE
Fix issue with 'delete' REST method

### DIFF
--- a/src/rest-api.js
+++ b/src/rest-api.js
@@ -68,7 +68,7 @@ function format(config, url) {
 }
 
 module.exports = function restAPI(config, url, method, params) {
-  if (method === 'del') { method = 'delete'; }
+  if (method === 'delete') { method = 'del'; }
   const token = config.get('sudo') ? config.get('secret') : (config.get('accessToken') || config.get('secret'));
   const conf = {
     token,


### PR DESCRIPTION
The [restler](https://github.com/danwrong/restler) npm module (which is a dependency of hull-node) doesn't appear to accept the string, 'delete' as an argument to specify the 'DELETE' REST method, it expects, 'del' so attempting to invoke the hull.del() won't work. This fixes the issue (at least for me)

Example error that this PR fixes:
```
/Users/phillipalexander/delete-test/node_modules/Hull/lib/rest-api.js:61
    throw new Error('Unsupported method ' + method);
    ^

Error: Unsupported method delete
    at perform (/Users/phillipalexander/delete-test/node_modules/Hull/lib/rest-api.js:61:11)
    at restAPI (/Users/phillipalexander/delete-test/node_modules/Hull/lib/rest-api.js:103:10)
    at Client._this.(anonymous function) [as del] (/Users/phillipalexander/delete-test/node_modules/Hull/lib/client.js:69:36)
    at Object.<anonymous> (/Users/phillipalexander/delete-test/index.js:14:6)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
```