### PR TITLE
Hotfix Pending promises issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.12.6
+* adds `PromiseReuser` class which allows us to handle in memory longer running promises and reuse them in case the same function is called multiple times with the same input
+
 # 0.12.5
 * upgrades hull-client to 1.1.3
 * update documentation about initialization of `QueueAdapter`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hull",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "A Node.js client for hull.io",
   "main": "lib",
   "repository": {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,3 +12,4 @@ export responseMiddleware from "./response-middleware";
 export notifMiddleware from "./notif-middleware";
 export segmentsMiddleware from "./segments-middleware";
 export helpersMiddleware from "./helpers-middleware";
+export PromiseReuser from "./promise-reuser";

--- a/src/utils/promise-reuser.js
+++ b/src/utils/promise-reuser.js
@@ -1,0 +1,56 @@
+// @flow
+
+/**
+ * Object which allows to reuse pending promises with the same
+ * arguments passed to original function
+ * Based on https://github.com/elado/reuse-promise
+ */
+export default class PromiseReuser {
+  options: Object
+  promiseMapsByArgs: Object
+
+  constructor(options: Object = {}) {
+    /**
+     * default serializing strategy
+     */
+    function serializeArguments(key) {
+      return JSON.stringify(key);
+    }
+
+    this.options = {
+      serializeArguments,
+      ...options
+    };
+    this.promiseMapsByArgs = {};
+  }
+
+  reusePromise(origFn: Function) {
+    const self = this;
+    function reusePromiseWrappedFn(...args: Array<any>) {
+      const key = self.options.serializeArguments(args);
+
+      const pendingPromise = self.promiseMapsByArgs[key];
+
+      if (pendingPromise) {
+        return pendingPromise;
+      }
+
+      const forgetPromise = () => delete self.promiseMapsByArgs[key];
+
+      const origPromise = origFn.apply(this, args);
+
+      const promise = origPromise.then((value) => {
+        forgetPromise();
+        return value;
+      }, (err) => {
+        forgetPromise();
+        throw err;
+      });
+      self.promiseMapsByArgs[key] = promise;
+
+      return promise;
+    }
+
+    return reusePromiseWrappedFn;
+  }
+}

--- a/src/utils/segments-middleware.js
+++ b/src/utils/segments-middleware.js
@@ -1,11 +1,14 @@
 import _ from "lodash";
 
+import { PromiseReuser } from ".";
+
 /**
  * @param  {Object}   req
  * @param  {Object}   res
  * @param  {Function} next
  */
 export default function segmentsMiddlewareFactory() {
+  const promiseReuser = new PromiseReuser();
   return function segmentsMiddleware(req, res, next) {
     req.hull = req.hull || {};
 
@@ -16,6 +19,7 @@ export default function segmentsMiddlewareFactory() {
     const { cache, message, connectorConfig } = req.hull;
     const bust = (message
       && (message.Subject === "users_segment:update" || message.Subject === "users_segment:delete"));
+    const reusableGet = promiseReuser.reusePromise(req.hull.client.get);
 
     return (() => {
       if (bust) {
@@ -24,7 +28,7 @@ export default function segmentsMiddlewareFactory() {
       return Promise.resolve();
     })().then(() => {
       return cache.wrap("segments", () => {
-        return req.hull.client.get("/segments", {}, {
+        return reusableGet("/segments", {}, {
           timeout: 5000,
           retry: 1000
         });

--- a/tests/client-middleware.js
+++ b/tests/client-middleware.js
@@ -2,6 +2,7 @@
 import { expect, should } from "chai";
 import sinon from "sinon";
 import Promise from "bluebird";
+import _ from "lodash";
 
 import Middleware from "../src/middleware/client";
 import HullStub from "./support/hull-stub";
@@ -123,6 +124,25 @@ describe("Client Middleware", () => {
     instance(this.reqStub, {}, () => {});
     instance(this.reqStub, {}, () => {
       expect(this.getStub.calledOnce).to.be.true;
+      done();
+    });
+  });
+
+  it("should call the API only once even for multiple concurrent inits, one call per ship id", function (done) {
+    const instance = Middleware(HullStub, { hostSecret: "secret" });
+    this.getStub.restore();
+    const reqStub2 = _.cloneDeep(this.reqStub);
+    reqStub2.query.ship = "ship_id2";
+    this.getStub = sinon.stub(HullStub.prototype, "get");
+    this.getStub.returns(Promise.resolve());
+    instance(this.reqStub, {}, () => {});
+    instance(reqStub2, {}, () => {});
+    instance(this.reqStub, {}, () => {});
+    instance(reqStub2, {}, () => {});
+    instance(this.reqStub, {}, () => {
+      expect(this.getStub.calledTwice).to.be.true;
+      expect(this.getStub.getCall(0).args[0]).to.equal("ship_id");
+      expect(this.getStub.getCall(1).args[0]).to.equal("ship_id2");
       done();
     });
   });

--- a/tests/client-middleware.js
+++ b/tests/client-middleware.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 import { expect, should } from "chai";
 import sinon from "sinon";
+import Promise from "bluebird";
 
 import Middleware from "../src/middleware/client";
 import HullStub from "./support/hull-stub";
@@ -110,6 +111,19 @@ describe("Client Middleware", () => {
         expect(this.getStub.calledTwice).to.be.true;
         done();
       });
+    });
+  });
+
+  it("should call the API only once even for multiple concurrent inits", function (done) {
+    const instance = Middleware(HullStub, { hostSecret: "secret" });
+    this.getStub.restore();
+    this.getStub = sinon.stub(HullStub.prototype, "get");
+    this.getStub.returns(Promise.resolve());
+    instance(this.reqStub, {}, () => {});
+    instance(this.reqStub, {}, () => {});
+    instance(this.reqStub, {}, () => {
+      expect(this.getStub.calledOnce).to.be.true;
+      done();
     });
   });
 


### PR DESCRIPTION
Problem to solve:

we are caching in memory ship/connector object and segments lists not to call API too often.
It looks like for high volume connectors when the cache object expires and before we fill it in with new, fresh object multiple calls are performed since time between next requests is much shorter than time to resolve the outgoing GET request.